### PR TITLE
Add support for other multipart/* content-types

### DIFF
--- a/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FilePart.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FilePart.java
@@ -1,0 +1,33 @@
+package com.braintreepayments.http.multipart;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URLConnection;
+import java.nio.channels.Channels;
+
+import static com.braintreepayments.http.serializer.Multipart.CRLF;
+
+public class FilePart extends FormData {
+
+	private File file;
+
+	public FilePart(String key, File file) {
+		super(key);
+		this.file = file;
+	}
+
+	@Override
+	public String header() {
+		return super.header() + String.format("; filename=\"%s\"%sContent-Type: %s", file.getName(), CRLF,
+						URLConnection.guessContentTypeFromName(file.getName()));
+	}
+
+	@Override
+	public void writeData(OutputStream os) throws IOException {
+		try (FileInputStream fis = new FileInputStream(this.file)) {
+			fis.getChannel().transferTo(0, this.file.length(), Channels.newChannel(os));
+		}
+	}
+}

--- a/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FormData.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FormData.java
@@ -1,0 +1,23 @@
+package com.braintreepayments.http.multipart;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public abstract class FormData {
+
+	private String key;
+
+	public FormData(String key) {
+		this.key = key;
+	}
+
+	public String key() {
+		return key;
+	}
+
+	public String header() {
+		return String.format("Content-Disposition: form-data; name=\"%s\"", key());
+	}
+
+	public abstract void writeData(OutputStream os) throws IOException;
+}

--- a/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FormPart.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/multipart/FormPart.java
@@ -1,0 +1,21 @@
+package com.braintreepayments.http.multipart;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.braintreepayments.http.serializer.StreamUtils.writeOutputStream;
+
+public class FormPart extends FormData {
+
+	private String value;
+
+	public FormPart(String key, String value) {
+		super(key);
+		this.value = value;
+	}
+
+	@Override
+	public void writeData(OutputStream os) throws IOException {
+		writeOutputStream(os, value);
+	}
+}

--- a/braintreehttp/src/main/java/com/braintreepayments/http/multipart/JsonPart.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/multipart/JsonPart.java
@@ -1,0 +1,37 @@
+package com.braintreepayments.http.multipart;
+
+import com.braintreepayments.http.Encoder;
+import com.braintreepayments.http.Headers;
+import com.braintreepayments.http.HttpRequest;
+import com.braintreepayments.http.serializer.StreamUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.braintreepayments.http.serializer.Multipart.CRLF;
+
+public class JsonPart extends FormData {
+
+	private Object value;
+	private String contentType;
+
+	public JsonPart(String key, Object value) {
+		super(key);
+		this.value = value;
+		this.contentType = "application/json";
+	}
+
+	@Override
+	public String header() {
+        return super.header() + String.format("; filename=\"%s.json\"%sContent-Type: %s", key(), CRLF, contentType);
+	}
+
+	@Override
+	public void writeData(OutputStream os) throws IOException {
+		HttpRequest fakeReq = new HttpRequest("/", "GET", Void.class)
+				.requestBody(value)
+				.header(Headers.CONTENT_TYPE, contentType);
+
+		StreamUtils.writeOutputStream(os, new Encoder().serializeRequest(fakeReq));
+	}
+}

--- a/braintreehttp/src/main/java/com/braintreepayments/http/multipart/MultipartBody.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/multipart/MultipartBody.java
@@ -1,0 +1,26 @@
+package com.braintreepayments.http.multipart;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class MultipartBody implements Iterable<FormData> {
+
+	private List<FormData> partList;
+
+	public MultipartBody(FormData... parts) {
+		this.partList = new ArrayList<>();
+
+		partList.addAll(Arrays.asList(parts));
+	}
+
+	public void addPart(FormData part) {
+		partList.add(part);
+	}
+
+	@Override
+	public Iterator<FormData> iterator() {
+		return partList.iterator();
+	}
+}

--- a/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Multipart.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Multipart.java
@@ -4,17 +4,19 @@ package com.braintreepayments.http.serializer;
 import com.braintreepayments.http.Headers;
 import com.braintreepayments.http.HttpRequest;
 import com.braintreepayments.http.exceptions.SerializeException;
+import com.braintreepayments.http.multipart.FormData;
+import com.braintreepayments.http.multipart.MultipartBody;
 
-import java.io.*;
-import java.net.URLConnection;
-import java.nio.channels.Channels;
-import java.util.Map;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 import static com.braintreepayments.http.serializer.StreamUtils.writeOutputStream;
 
 public class Multipart implements Serializer {
 
-	protected static final String CRLF = "\r\n";
+	public static final String CRLF = "\r\n";
 
 	@Override
 	public String contentType() {
@@ -22,25 +24,21 @@ public class Multipart implements Serializer {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public byte[] encode(HttpRequest request) throws IOException {
-		if (!(request.requestBody() instanceof Map)) {
-			throw new SerializeException("Request requestBody must be Map<String, Object> when Content-Type is multipart/*");
+		if (!(request.requestBody() instanceof MultipartBody)) {
+			throw new SerializeException("Request requestBody must be MultipartBody when Content-Type is multipart/*");
 		} else {
 			String contentType = request.headers().header(Headers.CONTENT_TYPE);
 			String boundary = "boundary" + System.currentTimeMillis();
 			contentType = contentType + "; boundary=" + boundary;
 			request.header(Headers.CONTENT_TYPE, contentType); // Rewrite header with boundary
 
-			Map<String, Object> body = (Map<String, Object>) request.requestBody();
-
+			MultipartBody body = (MultipartBody) request.requestBody();
 			ByteArrayOutputStream os = new ByteArrayOutputStream();
-			for (String key : body.keySet()) {
-				Object value = body.get(key);
-				if (value instanceof File) {
-					addFilePart(os, key, (File) value, boundary);
-				} else {
-					addFormPart(os, key, String.valueOf(value), boundary);
-				}
+
+			for (FormData formData : body) {
+				writePart(os, formData, boundary);
 			}
 
 			writeOutputStream(os, "--" + boundary + "--");
@@ -56,34 +54,14 @@ public class Multipart implements Serializer {
 		throw new UnsupportedEncodingException("Unable to decode Content-Type: multipart/form-data.");
 	}
 
-	private void writePartHeader(OutputStream writer, String name, String filename, String boundary) throws IOException {
+	private void writePart(OutputStream writer, FormData part, String boundary) throws IOException {
 		writeOutputStream(writer,"--" + boundary);
 		writeOutputStream(writer, CRLF);
-		writeOutputStream(writer, "Content-Disposition: form-data; name=\"" + name + "\"");
-		if (filename != null) {
-			writeOutputStream(writer, "; filename=\"" + filename + "\"");
-			writeOutputStream(writer, CRLF);
-			writeOutputStream(writer, "Content-Type: " + URLConnection.guessContentTypeFromName(filename));
-		}
+		writeOutputStream(writer, part.header());
 		writeOutputStream(writer, CRLF);
 		writeOutputStream(writer, CRLF);
-	}
 
-	private void addFormPart(OutputStream writer, String key, String value, String boundary) throws IOException {
-		writePartHeader(writer, key, null, boundary);
-
-		writeOutputStream(writer, value);
-		writeOutputStream(writer, CRLF);
-	}
-
-	private void addFilePart(OutputStream writer, String key, File uploadFile, String boundary)
-		throws IOException {
-		String filename = uploadFile.getName();
-		writePartHeader(writer, key, filename, boundary);
-
-		new FileInputStream(uploadFile).getChannel()
-				.transferTo(0, uploadFile.length(), Channels.newChannel(writer));
-
+		part.writeData(writer);
 		writeOutputStream(writer, CRLF);
 	}
 }

--- a/braintreehttp/src/test/java/com/braintreepayments/http/EncoderTest.java
+++ b/braintreehttp/src/test/java/com/braintreepayments/http/EncoderTest.java
@@ -1,5 +1,7 @@
 package com.braintreepayments.http;
 
+import com.braintreepayments.http.multipart.FormPart;
+import com.braintreepayments.http.multipart.MultipartBody;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -201,8 +203,7 @@ public class EncoderTest {
 		HttpRequest<Void> request = new HttpRequest("/", "POST", Void.class);
 		request.header("Content-Type", "multipart/form-data; charset=utf8");
 
-		Map<String, Object> body = new HashMap<>();
-		body.put("Key", "Value");
+		MultipartBody body = new MultipartBody(new FormPart("Key", "Value"));
 
 		request.requestBody(body);
 

--- a/braintreehttp/src/test/java/com/braintreepayments/http/serializer/MultipartTest.java
+++ b/braintreehttp/src/test/java/com/braintreepayments/http/serializer/MultipartTest.java
@@ -2,6 +2,11 @@ package com.braintreepayments.http.serializer;
 
 import com.braintreepayments.http.Headers;
 import com.braintreepayments.http.HttpRequest;
+import com.braintreepayments.http.Zoo;
+import com.braintreepayments.http.multipart.FilePart;
+import com.braintreepayments.http.multipart.FormPart;
+import com.braintreepayments.http.multipart.JsonPart;
+import com.braintreepayments.http.multipart.MultipartBody;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -10,8 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -27,16 +30,23 @@ public class MultipartTest {
 				.file("file_test_text", resource("fileupload_test_text.txt").toFile())
 				.formData("some_field_key", "form_field=\"some_field_value\"");
 
+		Zoo.Animal mixedPart = new Zoo.Animal();
+		mixedPart.age = 1;
+		mixedPart.carnivorous = true;
+
+		request.mixedData("some_mixed_part", mixedPart);
+
 		String serialized = new String(multipart.encode(request));
 
 		assertTrue(request.headers().header(Headers.CONTENT_TYPE).startsWith("multipart/form-data; boundary=boundary"));
-
 		assertTrue(serialized.contains("Content-Disposition: form-data; name=\"file_test_text\"; filename=\"fileupload_test_text.txt\""));
 		assertTrue(serialized.contains("Content-Type: text/plain"));
 		assertTrue(serialized.contains(uploadData));
 		assertTrue(serialized.contains("Content-Disposition: form-data; name=\"some_field_key\""));
 		assertTrue(serialized.contains("form_field=\"some_field_value\""));
 		assertTrue(serialized.contains("--boundary"));
+		assertTrue(serialized.contains("Content-Disposition: form-data; name=\"some_mixed_part\"; filename=\"some_mixed_part.json\"\r\nContent-Type: application/json"));
+		assertTrue(serialized.contains(new Json().serialize(mixedPart)));
 	}
 
 	@Test
@@ -54,14 +64,15 @@ public class MultipartTest {
 
 	@Test
 	public void testMultipart_serialize_throwsWhenBodyNotMap() throws IOException {
-		FileUploadRequest request = simpleFileRequest();
+		HttpRequest request = new HttpRequest("/", "POST", Void.class);
+		request.header(Headers.CONTENT_TYPE, "multipart/form-data");
 		request.requestBody(new Object());
 
 		try {
 			multipart.encode(request);
-			fail("Http client should have thrown for non-Map requestBody");
+			fail("Http client should have thrown for MultipartBody requestBody");
 		} catch (IOException ioe) {
-			assertEquals("Request requestBody must be Map<String, Object> when Content-Type is multipart/*", ioe.getMessage());
+			assertEquals("Request requestBody must be MultipartBody when Content-Type is multipart/*", ioe.getMessage());
 		}
 	}
 
@@ -73,6 +84,30 @@ public class MultipartTest {
 		} catch (IOException ioe) {
 			assertEquals("Unable to decode Content-Type: multipart/form-data.", ioe.getMessage());
 		}
+	}
+
+	@Test
+	public void testMultipart_serialize_binaryWithJsonPart() throws IOException {
+		FileUploadRequest request = new FileUploadRequest("/multipart", "POST", Void.class)
+		    .file("file_test_image", resource("fileupload_test_binary.jpg").toFile());
+
+		Zoo.Animal mixedPart = new Zoo.Animal();
+		mixedPart.age = 1;
+		mixedPart.carnivorous = true;
+		request.mixedData("some_mixed_part", mixedPart);
+
+		byte[] data = multipart.encode(request);
+
+		assertTrue(request.headers().header(Headers.CONTENT_TYPE).startsWith("multipart/form-data; boundary=boundary"));
+
+		assertTrue(byteArrayContains(data, "Content-Disposition: form-data; name=\"file_test_image\"; filename=\"fileupload_test_binary.jpg\"".getBytes()));
+		assertTrue(byteArrayContains(data, "Content-Type: image/jpeg".getBytes()));
+		byte[] imageData = fileData("fileupload_test_binary.jpg");
+		assertTrue(byteArrayContains(data, imageData));
+
+		assertTrue(byteArrayContains(data, "--boundary".getBytes()));
+		assertTrue(byteArrayContains(data, "Content-Disposition: form-data; name=\"some_mixed_part\"; filename=\"some_mixed_part.json\"\r\nContent-Type: application/json".getBytes()));
+		assertTrue(byteArrayContains(data, new Json().serialize(mixedPart).getBytes()));
 	}
 
 	private boolean byteArrayContains(byte[] b1, byte[] subba) {
@@ -99,24 +134,35 @@ public class MultipartTest {
 
 	private class FileUploadRequest extends HttpRequest<Void> {
 
+		private MultipartBody multipartBody;
+
 		public FileUploadRequest(String path, String verb, Class<Void> responseClass) {
 			super(path, verb, responseClass);
 			header(Headers.CONTENT_TYPE, "multipart/form-data");
-			requestBody(new HashMap<String, Object>());
+			multipartBody = new MultipartBody();
 		}
 
+		@SuppressWarnings("unchecked")
 		public FileUploadRequest file(String key, File f) {
-			Map<String, Object> existingBody = ((Map<String, Object>) requestBody());
-			existingBody.put(key, f);
-			requestBody(existingBody);
+			multipartBody.addPart(new FilePart(key, f));
 			return this;
 		}
 
+		@SuppressWarnings("unchecked")
 		public FileUploadRequest formData(String key, String value) {
-			Map<String, Object> existingBody = ((Map<String, Object>) requestBody());
-			existingBody.put(key, value);
-			requestBody(existingBody);
+			multipartBody.addPart(new FormPart(key, value));
 			return this;
+		}
+
+		@SuppressWarnings("unchecked")
+		public FileUploadRequest mixedData(String key, Object data) {
+			multipartBody.addPart(new JsonPart(key, data));
+			return this;
+		}
+
+		@Override
+		public Object requestBody() {
+			return multipartBody;
 		}
 	}
 }


### PR DESCRIPTION
- Add wrapper MultipartBody class specifically for multipart requests
- Remove unused function
- Close the FileInputStream when finished in FilePart
- Rename MixedPart to JsonPart
- Specialized for the filename added to the headers