### PR TITLE
force UTF-8 encoding when creating byte arrays from Strings

### DIFF
--- a/braintreehttp/src/main/java/com/braintreepayments/http/serializer/FormEncoded.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/serializer/FormEncoded.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class FormEncoded implements Serializer {
 
 	@Override
@@ -31,7 +33,7 @@ public class FormEncoded implements Serializer {
 			parts.add(key + "=" + urlEscape(body.get(key)));
 		}
 
-		return String.join("&", parts).getBytes();
+		return String.join("&", parts).getBytes(UTF_8);
 	}
 
 	@Override

--- a/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Json.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Json.java
@@ -10,6 +10,8 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class Json implements Serializer {
 
 	private static final char OBJECT_TOKEN_OPEN = '{';
@@ -79,7 +81,7 @@ public class Json implements Serializer {
 
 	@Override
 	public byte[] encode(HttpRequest request) throws SerializeException {
-		return serialize(request.requestBody()).getBytes();
+		return serialize(request.requestBody()).getBytes(UTF_8);
 	}
 
 	public String serialize(Object o) throws SerializeException {

--- a/braintreehttp/src/main/java/com/braintreepayments/http/serializer/StreamUtils.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/serializer/StreamUtils.java
@@ -35,7 +35,7 @@ public class StreamUtils {
 	}
 
 	public static void writeOutputStream(OutputStream outputStream, String data) throws IOException {
-		writeOutputStream(outputStream, data.getBytes());
+		writeOutputStream(outputStream, data.getBytes(UTF_8));
 	}
 
 	public static void writeOutputStream(OutputStream outputStream, byte[] data) throws IOException {

--- a/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Text.java
+++ b/braintreehttp/src/main/java/com/braintreepayments/http/serializer/Text.java
@@ -5,6 +5,8 @@ import com.braintreepayments.http.HttpRequest;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class Text implements Serializer {
 
 	@Override
@@ -15,9 +17,9 @@ public class Text implements Serializer {
 	@Override
 	public byte[] encode(HttpRequest request) throws IOException {
 		if (request.requestBody() instanceof String) {
-			return ((String) request.requestBody()).getBytes();
+			return ((String) request.requestBody()).getBytes(UTF_8);
 		} else {
-			return request.requestBody().toString().getBytes();
+			return request.requestBody().toString().getBytes(UTF_8);
 		}
 	}
 


### PR DESCRIPTION
We have a problem on Windows machines with product names containing umlauts. Forcing the UTF-8 encoding fixes this problem.